### PR TITLE
Fixes in "4.BacktestingWithHistoricalData.ipynb" and "utility.py"

### DIFF
--- a/getting_started/4.BacktestingWithHistoricalData.ipynb
+++ b/getting_started/4.BacktestingWithHistoricalData.ipynb
@@ -243,8 +243,9 @@
    "source": [
     "anomaly_groups = []\n",
     "next_token = None\n",
+    "first_response = None\n",
     "\n",
-    "while True:    \n",
+    "while True:\n",
     "    params = {\n",
     "        \"AnomalyDetectorArn\" : anomaly_detector_arn,\n",
     "        \"SensitivityThreshold\" : 50,\n",
@@ -255,7 +256,8 @@
     "        params[\"NextToken\"] = next_token\n",
     "    \n",
     "    response = L4M.list_anomaly_group_summaries( **params )\n",
-    "    stats = response[\"AnomalyGroupStatistics\"]\n",
+    "    if first_response is None:\n",
+    "        first_response = response\n",
     "    \n",
     "    anomaly_groups += response[\"AnomalyGroupSummaryList\"]\n",
     "    \n",
@@ -264,7 +266,7 @@
     "        continue\n",
     "    break\n",
     "\n",
-    "stats"
+    "first_response"
    ]
   },
   {
@@ -286,19 +288,47 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "anomaly_group_id = anomaly_groups[0][\"AnomalyGroupId\"]\n",
     "\n",
-    "response = L4M.list_anomaly_group_time_series(AnomalyDetectorArn = anomaly_detector_arn,\n",
-    "                                   AnomalyGroupId=anomaly_group_id,\n",
-    "                                   MetricName='views',\n",
-    "                                   MaxResults=10,\n",
-    "                                  )\n",
-    "response"
+    "anomaly_group_time_series = []\n",
+    "next_token = None\n",
+    "first_response = None\n",
+    "\n",
+    "while True:\n",
+    "    params = {\n",
+    "        \"AnomalyDetectorArn\" : anomaly_detector_arn,\n",
+    "        \"AnomalyGroupId\" : anomaly_group_id,\n",
+    "        \"MetricName\" : \"views\",\n",
+    "        \"MaxResults\" : 10,\n",
+    "    }\n",
+    "    \n",
+    "    if next_token:\n",
+    "        params[\"NextToken\"] = next_token\n",
+    "\n",
+    "    response = L4M.list_anomaly_group_time_series( **params )\n",
+    "    if first_response is None:\n",
+    "        first_response = response\n",
+    "    \n",
+    "    anomaly_group_time_series += response[\"TimeSeriesList\"]\n",
+    "    \n",
+    "    if \"NextToken\" in response:\n",
+    "        next_token = response[\"NextToken\"]\n",
+    "        continue\n",
+    "    break\n",
+    "\n",
+    "first_response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "anomaly_group_time_series"
    ]
   },
   {
@@ -323,8 +353,9 @@
     "    delete_resources = False\n",
     "    \n",
     "if delete_resources:\n",
-    "    #L4M.delete_anomaly_detector( AnomalyDetectorArn = anomaly_detector_arn )\n",
+    "    L4M.delete_anomaly_detector( AnomalyDetectorArn = anomaly_detector_arn )\n",
     "    utility.wait_delete_anomaly_detector( L4M, anomaly_detector_arn )\n",
+    "    utility.delete_iam_role(role_name)\n",
     "else:\n",
     "    print(\"Not deteleting resources.\")"
    ]

--- a/getting_started/utility.py
+++ b/getting_started/utility.py
@@ -81,26 +81,6 @@ def get_or_create_iam_role( role_name ):
                     "Service": "lookoutmetrics.amazonaws.com"
                 },
                 "Action": "sts:AssumeRole"
-            },
-
-            # FIXME : for alpha
-            {
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn:aws:iam::036918044585:root"
-                },
-                "Action": "sts:AssumeRole",
-                "Condition": {}
-            },
-
-            # FIXME : for beta
-            {
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn:aws:iam::458402630025:root"
-                },
-                "Action": "sts:AssumeRole",
-                "Condition": {}
             }
         ]
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Deleted unnecessary service principle entries in utility.py.

- Implemented pagination of list_anomaly_group_time_series().

- Print the entire response from list_anomaly_group_summaries() so that customers can see how it is structured, and stop getting "AnomalyGroupStatistics" from the result of list_anomaly_group_summaries(). ("AnomalyGroupStatistics" exists only in the first response.)

- delete_anomaly_detector() API was commented out unintentionally. Enabled it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
