### PR TITLE
Use %pip magic command instead of !pip, to be environment independent.

### DIFF
--- a/getting_started/1.PrereqSetupPackages.ipynb
+++ b/getting_started/1.PrereqSetupPackages.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip uninstall -y awscli"
+    "%pip uninstall -y awscli"
    ]
   },
   {
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip uninstall -y boto3"
+    "%pip uninstall -y boto3"
    ]
   },
   {
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip uninstall -y botocore"
+    "%pip uninstall -y botocore"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install {sdk_extract_dst}/{botocore_whl}"
+    "%pip install {sdk_extract_dst}/{botocore_whl}"
    ]
   },
   {
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install {sdk_extract_dst}/{awscli_whl}"
+    "%pip install {sdk_extract_dst}/{awscli_whl}"
    ]
   },
   {
@@ -174,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install {sdk_extract_dst}/{boto3_whl}"
+    "%pip install {sdk_extract_dst}/{boto3_whl}"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-samples/amazon-lookout-for-metrics-samples/issues/16

*Description of changes:*

Use %pip magic command instead of !pip, to be environment independent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
