### PR TITLE
Updated ecommerce.zip dataset to include more recent period

### DIFF
--- a/getting_started/2.PrereqSetupData.ipynb
+++ b/getting_started/2.PrereqSetupData.ipynb
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " Specifically, notice that we only have one `input.csv` in the `backtest`. Whereas, data in the `live` folder is broken down into days (ex: `20201001` for October 1, 2020) and hours (ex: `0200` for 2:00AM). \n",
+    " Specifically, notice that we only have one `input.csv` in the `backtest`. Whereas, data in the `live` folder is broken down into days (ex: `20210101` for January 1, 2021) and hours (ex: `0200` for 2:00AM). \n",
     "\n",
     "This path structure for the live data is *CRITICAL* for using the service, your own datasets must be built in a similar manner so that Lookout for Metrics will understand how to find data in the future. Soon we will have a sample that showcases how to stream data from Lambda or Kinesis into a structure like this.\n",
     "\n",
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "live_sample_df = pd.read_csv('data/ecommerce/live/20201208/0000/20201208_000000.csv')\n",
+    "live_sample_df = pd.read_csv('data/ecommerce/live/20210308/0000/20210308_000000.csv')\n",
     "live_sample_df.head()"
    ]
   },


### PR DESCRIPTION
*Description of changes:*

Updated ecommerce.zip dataset to include more recent period (2021-01-01 ~ 2021-09-30).
Previous version of the dataset was going to expire by 2020-03-31.

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
