### PR TITLE
L4m2quicksight cdk

### DIFF
--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -81,7 +81,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
-Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk). If your download doesn't automatically start, click the **Download** button on the page that opens.
+Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk target=”_blank”). If your download doesn't automatically start, click the **Download** button on the page that opens.
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -76,14 +76,25 @@ Open the [SageMaker console](https://console.aws.amazon.com/sagemaker/), and ope
 ## III. CDK Prerequisites
 The instructions below assume familiarity with AWS CDK. If you need to set these up, start with [the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) and [the AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) documentation. The instructions below reference using named profiles. If you use more than one AWS environment, it is recommended to [setup named profiles on your system](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html).
 
-## IV. Clone the repository
+## IV. Download the GitHub Repository Folder
 
-#### Create a new project folder and clone the example repository.
+#### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
+
+1. Browse to [the DownGit Repository URL](https://github.com/MinhasKamal/DownGit).
+2. Review the docs and click the link to [the DownGit web site](https://downgit.github.io).
+2. Paste [the l4m2quicksight-cdk folder](https://github.com/aws-samples/amazon-lookout-for-metrics-samples/next_steps/l4m2quicksight-cdk) URL in the **GitHub Directory or File** text box.
+```
+https://github.com/aws-samples/amazon-lookout-for-metrics-samples/next_steps/l4m2quicksight-cdk
+```
+
+#### Create a new project folder, copy the example repository folder, and set it as your working directory.
 
 ```bash
 $ mkdir <project directory>
 $ cd <project directory>
-$ git clone https://github.com/troiano01/l4m2quicksight-cdk.git
+$ cp <download path>/amazon-lookout-for-metrics-samples-l4m2quicksight-cdk.zip .
+$ unzip amazon-lookout-for-metrics-samples-l4m2quicksight-cdk.zip
+$ cd amazon-lookout-for-metrics-samples-l4m2quicksight-cdk
 ```
 
 ## V. Set the Environment Parameters in the cdk.json

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -80,10 +80,8 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
-<a href="https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk" target="_blank">this DownGit link</a>
-
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
-Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk?target="_blank"). If your download doesn't automatically start, click the **Download** button on the page that opens.
+Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk). If your download doesn't automatically start, click the **Download** button on the page that opens.
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -81,7 +81,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
-Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk target=”_blank”). If your download doesn't automatically start, click the **Download** button on the page that opens.
+Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using <a href="https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk" target="_blank">this DownGit link</a>. If your download doesn't automatically start, click the **Download** button on the tab that opens.
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -78,7 +78,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 
 ## IV. Download the GitHub Repository Folder
 
-#### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
+#### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Samples Repository
 
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
 Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk). If your download doesn't automatically start, click the **Download** button on the page that opens.

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -81,7 +81,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Samples Repository
 
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
-Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk). If your download doesn't automatically start, click the **Download** button on the page that opens.
+Download only the l4m2quicksight-cdk folder to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk). If your download doesn't automatically start, click the **Download** button on the page that opens.
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -80,7 +80,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
-This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repsository.
+This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
 Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk).
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -81,7 +81,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repsository.
-Download only [the l4m2quicksight-cdk folder] using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk).
+Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk).
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -80,8 +80,10 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
+<a href="https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk" target="_blank">this DownGit link</a>
+
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
-Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using <a href="https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk" target="_blank">this DownGit link</a>. If your download doesn't automatically start, click the **Download** button on the tab that opens.
+Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk){:target="_blank"}. If your download doesn't automatically start, click the **Download** button on the page that opens.
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -83,7 +83,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 <a href="https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk" target="_blank">this DownGit link</a>
 
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
-Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk){:target="_blank"}. If your download doesn't automatically start, click the **Download** button on the page that opens.
+Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk?target="_blank"). If your download doesn't automatically start, click the **Download** button on the page that opens.
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -80,6 +80,11 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
+[test](https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk)
+
+
+https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk
+
 1. Browse to [the DownGit Repository URL](https://github.com/MinhasKamal/DownGit).
 2. Review the docs and click the link to [the DownGit web site](https://downgit.github.io).
 2. Paste [the l4m2quicksight-cdk folder](https://github.com/aws-samples/amazon-lookout-for-metrics-samples/next_steps/l4m2quicksight-cdk) URL in the **GitHub Directory or File** text box.

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -81,7 +81,7 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
 This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repository.
-Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk).
+Download only [the l4m2quicksight-cdk folder] to your browser's downloads folder location using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk). If your download doesn't automatically start, click the **Download** button on the page that opens.
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 

--- a/next_steps/l4m2quicksight-cdk/README.md
+++ b/next_steps/l4m2quicksight-cdk/README.md
@@ -80,26 +80,17 @@ The instructions below assume familiarity with AWS CDK. If you need to set these
 
 #### Download the l4m2quicksight-cdk folder from the Lookout For Metrics AWS Smaples Repository
 
-[test](https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk)
-
-
-https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk
-
-1. Browse to [the DownGit Repository URL](https://github.com/MinhasKamal/DownGit).
-2. Review the docs and click the link to [the DownGit web site](https://downgit.github.io).
-2. Paste [the l4m2quicksight-cdk folder](https://github.com/aws-samples/amazon-lookout-for-metrics-samples/next_steps/l4m2quicksight-cdk) URL in the **GitHub Directory or File** text box.
-```
-https://github.com/aws-samples/amazon-lookout-for-metrics-samples/next_steps/l4m2quicksight-cdk
-```
+This step uses [the DownGit utility](https://github.com/MinhasKamal/DownGit) to simplify the download of the directory without having to clone the entire AWS Samples L4M repsository.
+Download only [the l4m2quicksight-cdk folder] using [this DownGit link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/aws-samples/amazon-lookout-for-metrics-samples/tree/main/next_steps/l4m2quicksight-cdk&fileName=l4m2quicksight-cdk&rootDirectory=l4m2quicksight-cdk).
 
 #### Create a new project folder, copy the example repository folder, and set it as your working directory.
 
 ```bash
 $ mkdir <project directory>
 $ cd <project directory>
-$ cp <download path>/amazon-lookout-for-metrics-samples-l4m2quicksight-cdk.zip .
-$ unzip amazon-lookout-for-metrics-samples-l4m2quicksight-cdk.zip
-$ cd amazon-lookout-for-metrics-samples-l4m2quicksight-cdk
+$ cp <download path>/l4m2quicksight-cdk.zip .
+$ unzip l4m2quicksight-cdk.zip
+$ cd l4m2quicksight-cdk
 ```
 
 ## V. Set the Environment Parameters in the cdk.json


### PR DESCRIPTION
Updated l4m2quicksight-cdk to use DownGit to download the project folder, instead of cloning the full repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
